### PR TITLE
Use #latest tag with Heroku node buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-nodejs.git#latest
 https://github.com/mars/create-react-app-inner-buildpack.git#v9.0.0
 https://github.com/heroku/heroku-buildpack-static.git


### PR DESCRIPTION
Heroku has added a #latest tag. 

Incidentally this resolves some issues non-Heroku uses of this buildpack have (#181).